### PR TITLE
Updates tag to latest in ci.yml as a test for semantic-versioning composite action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
           fetch-depth: 0
 
       - name: YAML Lint and Shellcheck
-        uses: jason-idk/gh-actions/.github/actions/gha-linter@feature/baseline-actions
+        uses: jason-idk/gh-actions/.github/actions/gha-linter@latest
 
       - name: Semantic versioning
-        uses: jason-idk/gh-actions/.github/actions/semantic-versioning@feature/baseline-actions
+        uses: jason-idk/gh-actions/.github/actions/semantic-versioning@latest
         with:
           main_branch: main


### PR DESCRIPTION
As stated in previous PR, bumps tag in ci.yml for both actions to point to latest. This will result in a new tag of v0.1.1 if all goes as planned. 